### PR TITLE
Correctly parse minus and plus operators between numbers without spaces

### DIFF
--- a/src/erlyjs_parser.yrl
+++ b/src/erlyjs_parser.yrl
@@ -210,8 +210,8 @@ UnaryExpression -> void UnaryExpression : {op, '$1', '$2'}. % TODO
 UnaryExpression -> typeof UnaryExpression : {op, '$1', '$2'}. % TODO
 UnaryExpression -> '++' UnaryExpression : {op, '$1', '$2'}.
 UnaryExpression -> '--' UnaryExpression : {op, '$1', '$2'}.
-UnaryExpression -> '+' UnaryExpression : {op, '$1', '$2'}.
-UnaryExpression -> '-' UnaryExpression : {op, '$1', '$2'}.
+UnaryExpression -> '+' UnaryExpression : plus('$1', '$2').
+UnaryExpression -> '-' UnaryExpression : minus('$1', '$2').
 UnaryExpression -> '~' UnaryExpression : {op, '$1', '$2'}.
 UnaryExpression -> '!' UnaryExpression : {op, '$1', '$2'}.
 
@@ -409,6 +409,14 @@ TopStatement -> FunctionDefinition  : '$1'.
 
 
 Erlang code.
+
+minus(_, {integer, Line, Value}) -> {integer, Line, -Value};
+minus(_, {float, Line, Value}) -> {float, Line, -Value};
+minus(Op, Exp) -> {op, Op, Exp}.
+
+plus(_, Int = {integer, _, _}) -> Int;
+plus(_, Float = {float, _, _}) -> Float;
+plus(Op, Exp) -> {op, Op, Exp}.
 
 postfix({Op, Line}) -> {Op, postfix, Line}.
 

--- a/src/erlyjs_scan.xrl
+++ b/src/erlyjs_scan.xrl
@@ -49,9 +49,9 @@ Comment = (/\*(.|[\r\n])*?\*/|//.*)
 
 Rules.   
 
-(\+|\-)?{Digit}+\.{Digit}+ : build_float(TokenChars, TokenLine).
+{Digit}+\.{Digit}+ : build_float(TokenChars, TokenLine).
 
-(\+|\-)?{Digit}+ : build_integer(TokenChars, TokenLine).
+{Digit}+ : build_integer(TokenChars, TokenLine).
 
 {String} : build_string(TokenChars, TokenLine, TokenLen).
 


### PR DESCRIPTION
I fixed the parsing of minus and plus operators when there is no spaces.
For example "1-1" or "2-3.5".
